### PR TITLE
Settings: Updates Headings to Titlecase

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "time-block-planner",
-  "name": "Time Block planner",
+  "name": "Time Block Planner",
   "version": "0.1.2",
   "minAppVersion": "0.16.0",
   "description": "A day planner with clean UI and readable syntax",

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -93,7 +93,7 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Start hour")
+      .setName("Start Hour")
       .setDesc("The planner is going to start at this hour each day")
       .addDropdown((component) =>
         component
@@ -124,7 +124,7 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Date format in timeline header")
+      .setName("Date Format in Timeline Header")
       .then((component) => {
         component.setDesc(
           createFragment((fragment) => {
@@ -158,7 +158,7 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Center the pointer in the timeline view")
+      .setName("Center the Pointer in the Timeline View")
       .setDesc(
         "Should the pointer continuously get scrolled to the center of the view",
       )
@@ -174,7 +174,7 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
-      .setName("Planner heading")
+      .setName("Planner Heading")
       .setDesc(
         `When you create a planner, this text is going to be in the heading.
 When you open a file, the plugin will search for this heading to detect a day plan`,


### PR DESCRIPTION
Currently the headings of the settings option and the Settings in Obsidian are mixed case; some are titlecase and some are first letter capitalised of sentence. This makes them titlecase for uniformity. This will close #7 