### PR TITLE
:sparkles: Update task.svelte to honour theme styling

### DIFF
--- a/src/ui/components/task.svelte
+++ b/src/ui/components/task.svelte
@@ -123,6 +123,18 @@
     transition: 0.05s linear;
   }
 
+  .task a {
+    color: var(--text-on-accent);
+    font-weight: 500;
+    text-decoration-line: var(--link-decoration);
+  }
+
+  .task a:hover {
+    color: var(--text-accent-hover);
+    font-weight: 600;
+    cursor: grab;
+  }
+
   .is-ghost {
     opacity: 60%;
   }


### PR DESCRIPTION
This is a minor tweak that should fix the link styling with certain themes. I added minor font weight increases as well for readability in the cases where the accent-text is more muted.

This should close #12.